### PR TITLE
fix: remove more than 1 model from simple mode

### DIFF
--- a/The_Simple_Stable_Horde_Colab.ipynb
+++ b/The_Simple_Stable_Horde_Colab.ipynb
@@ -4,8 +4,7 @@
   "metadata": {
     "accelerator": "GPU",
     "colab": {
-      "provenance": [],
-      "include_colab_link": true
+      "provenance": []
     },
     "kernelspec": {
       "display_name": "Python 3",
@@ -87,7 +86,7 @@
         "  allow_painting = False\n",
         "  dynamic_models = False\n",
         "  max_power = 16\n",
-        "  models_to_load = [\"Deliberate\", \"Anything Diffusion\"]\n",
+        "  models_to_load = [\"top 1\"]\n",
         "  models_to_skip = [\"stable_diffusion_inpainting\", \"stable_diffusion_2.1\",  \"stable_diffusion_2.0\"]\n",
         "  allow_post_processing = False\n",
         "\n",


### PR DESCRIPTION
A new memory leak has snuck in, and while performance is better, more than one model has a memory leak.